### PR TITLE
Updated colors

### DIFF
--- a/BossMod/BossModule/BossModule.cs
+++ b/BossMod/BossModule/BossModule.cs
@@ -13,6 +13,13 @@ public abstract class BossModule : IDisposable
     public readonly ModuleRegistry.Info? Info;
     public readonly StateMachine StateMachine;
 
+    private readonly Color TankColor = Color.FromComponents(30, 50, 110);
+    private readonly Color HealerColor = Color.FromComponents(30, 110, 50);
+    private readonly Color MeleeColor = Color.FromComponents(110, 30, 30);
+    private readonly Color CasterColor = Color.FromComponents(70, 30, 110);
+    private readonly Color RangedColor = Color.FromComponents(110, 90, 30);
+    private readonly Color FocusColor = Color.FromComponents(0, 255, 255);
+
     private readonly EventSubscriptions _subscriptions;
 
     public Event<BossModule, BossComponent?, string> Error = new();
@@ -331,24 +338,26 @@ public abstract class BossModule : IDisposable
                 {
                     if (isFocus)
                     {
-                        color = ImGui.ColorConvertFloat4ToU32(new Vector4(1, 1, 0, 1));
+                        color = FocusColor.ABGR;
                     }
                     else if (WindowConfig.ColorPlayersBasedOnRole)
                     {
-                        switch (player.Role)
+                        switch (player.ClassCategory)
                         {
-                            case Role.Melee:
-                            case Role.Ranged:
-                                color = ImGui.ColorConvertFloat4ToU32(new Vector4(1, 0, 0, 1));
+                            case ClassCategory.Tank:
+                                color = TankColor.ABGR;
                                 break;
-                            case Role.Tank:
-                                color = ImGui.ColorConvertFloat4ToU32(new Vector4(0, 0, 1, 1));
+                            case ClassCategory.Healer:
+                                color = HealerColor.ABGR;
                                 break;
-                            case Role.Healer:
-                                color = ImGui.ColorConvertFloat4ToU32(new Vector4(0, 1, 0, 1));
+                            case ClassCategory.Melee:
+                                color = MeleeColor.ABGR;
                                 break;
-                            case Role.None:
-                            default:
+                            case ClassCategory.Caster:
+                                color = CasterColor.ABGR;
+                                break;
+                            case ClassCategory.PhysRanged:
+                                color = RangedColor.ABGR;
                                 break;
                         }
                     }

--- a/BossMod/BossModule/BossModule.cs
+++ b/BossMod/BossModule/BossModule.cs
@@ -326,11 +326,28 @@ public abstract class BossModule : IDisposable
                     var colors = Service.Config.Get<ColorConfig>();
                     if (isFocus)
                     {
-                        color = colors.FocusTargetColor.ABGR;
+                        color = colors.PlayerColorsFocus.ABGR;
                     }
                     else if (WindowConfig.ColorPlayersBasedOnRole)
                     {
-                        color = colors.PlayerColors[(int)player.Role].ABGR;
+                        switch (player.ClassCategory)
+                        {
+                            case ClassCategory.Tank:
+                                color = colors.PlayerColorsTank.ABGR;
+                                break;
+                            case ClassCategory.Healer:
+                                color = colors.PlayerColorsHealer.ABGR;
+                                break;
+                            case ClassCategory.Melee:
+                                color = colors.PlayerColorsMelee.ABGR;
+                                break;
+                            case ClassCategory.Caster:
+                                color = colors.PlayerColorsCaster.ABGR;
+                                break;
+                            case ClassCategory.PhysRanged:
+                                color = colors.PlayerColorsPhysRanged.ABGR;
+                                break;
+                        }
                     }
                 }
             }

--- a/BossMod/Config/ColorConfig.cs
+++ b/BossMod/Config/ColorConfig.cs
@@ -21,9 +21,21 @@ public sealed class ColorConfig : ConfigNode
     [PropertyDisplay("Planner: window")]
     public Color[] PlannerWindow = [new(0x800089b5), new(0x80164bcb), new(0x802f32dc), new(0x808236d3), new(0x80c4716c), new(0x80d28b26), new(0x8098a12a), new(0x80009985)]; // solarized accents
 
-    [PropertyDisplay("Player Colors")]
-    public Color[] PlayerColors = [new(0xff808080), new(0xc0d28b26), new(0xc0519d43), new(0xc02f32dc), new(0xc06436dc)]; // follows role enum
+    [PropertyDisplay("Player colors: tank")]
+    public Color PlayerColorsTank = new(Color.FromComponents(30, 50, 110).ABGR);
 
-    [PropertyDisplay("Focus Target Color")]
-    public Color FocusTargetColor = new(0xff0089b5);
+    [PropertyDisplay("Player colors: healer")]
+    public Color PlayerColorsHealer = new(Color.FromComponents(30, 110, 50).ABGR);
+
+    [PropertyDisplay("Player colors: melee")]
+    public Color PlayerColorsMelee = new(Color.FromComponents(110, 30, 30).ABGR);
+
+    [PropertyDisplay("Player colors: caster")]
+    public Color PlayerColorsCaster = new(Color.FromComponents(70, 30, 110).ABGR);
+
+    [PropertyDisplay("Player colors: phys. ranged")]
+    public Color PlayerColorsPhysRanged = new(Color.FromComponents(110, 90, 30).ABGR);
+
+    [PropertyDisplay("Player colors: focus")]
+    public Color PlayerColorsFocus = new(Color.FromComponents(0, 255, 255).ABGR);
 }

--- a/BossMod/Data/Actor.cs
+++ b/BossMod/Data/Actor.cs
@@ -107,6 +107,7 @@ public sealed class Actor(ulong instanceID, uint oid, int spawnIndex, string nam
     public ActorStatus[] Statuses = new ActorStatus[60]; // empty slots have ID=0
 
     public Role Role => Class.GetRole();
+    public ClassCategory ClassCategory => Class.GetClassCategory();
     public WPos Position => new(PosRot.X, PosRot.Z);
     public WPos PrevPosition => new(PrevPosRot.X, PrevPosRot.Z);
     public Angle Rotation => PosRot.W.Radians();


### PR DESCRIPTION
- Moved colors to private variables (also easier to set since the variables are RGB) at the top of the file; veyn said he will be moving these to the config at some point so it makes it easier for him
- Changed the role-based colors to job-based colors
- Updated colors to be more "muted" so it's still easy to tell which triangle is the boss and which is the player

Examples:
![image](https://github.com/user-attachments/assets/8cf04c8c-5d18-46fd-b738-f936dbdbc79c)
![image](https://github.com/user-attachments/assets/5d01f96d-7663-4ca7-90ea-8ff58df820b7)
![image](https://github.com/user-attachments/assets/957edfca-5be8-445f-8f71-759d8685c4d0)
